### PR TITLE
Feature/add mock api response with delay

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'androidx.lifecycle:lifecycle-process:2.3.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/java/com/example/networkobserverdemo/MyApplication.kt
+++ b/app/src/main/java/com/example/networkobserverdemo/MyApplication.kt
@@ -13,26 +13,23 @@ import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.example.networkobserverdemo.data.source.remote.ApiClient
 import com.example.networkobserverdemo.ui.SubActivity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlin.coroutines.CoroutineContext
 
-class MyApplication : Application(), LifecycleObserver {
+class MyApplication : Application(), LifecycleObserver, CoroutineScope {
     
     companion object {
         private const val TAG = "MyApp" + " mori"
         private lateinit var networkCallback: NetworkCallback
     }
 
-    private val scope = CoroutineScope(Job() + Dispatchers.Main)
+    private lateinit var job: Job
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main + job
 
     private val wifiCallback: (Boolean) -> Unit = { isWifi ->
         Log.d(TAG, "isWifi: $isWifi, request api")
-        scope.launch {
-            val result = ApiClient().getMockResponse()
-            if (result) launchSubActivity()
-        }
+        requestApi()
     }
 
     override fun onCreate() {
@@ -50,6 +47,8 @@ class MyApplication : Application(), LifecycleObserver {
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun onApplicationStart() {
         Log.d(TAG, "_onApplicationStart")
+        job = Job() // set new job (it starts active)
+        Log.d(TAG, "job: $job")
         requestNetwork()
     }
 
@@ -66,6 +65,9 @@ class MyApplication : Application(), LifecycleObserver {
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onApplicationStop() {
         Log.d(TAG, "_onApplicationStop")
+        Log.d(TAG, "before cancel. job: $job")
+        job.cancel() // cancel current job (it will be cancelled)
+        Log.d(TAG, "after cancel. job: $job")
         unregisterNetwork()
     }
 
@@ -90,6 +92,15 @@ class MyApplication : Application(), LifecycleObserver {
 //        Log.d(TAG, "cm:$cm")
         cm.unregisterNetworkCallback(networkCallback)
         Log.d(TAG, "released network request")
+    }
+
+    private fun requestApi() {
+        Log.d(TAG, "coroutineContext: $coroutineContext")
+        launch {
+            Log.d(TAG, "coroutineScope: $this")
+            val result = ApiClient().getMockResponse()
+            if (result) launchSubActivity()
+        }
     }
 
     private fun launchSubActivity() {

--- a/app/src/main/java/com/example/networkobserverdemo/MyApplication.kt
+++ b/app/src/main/java/com/example/networkobserverdemo/MyApplication.kt
@@ -11,7 +11,12 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.example.networkobserverdemo.data.source.remote.ApiClient
 import com.example.networkobserverdemo.ui.SubActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 class MyApplication : Application(), LifecycleObserver {
     
@@ -20,9 +25,14 @@ class MyApplication : Application(), LifecycleObserver {
         private lateinit var networkCallback: NetworkCallback
     }
 
+    private val scope = CoroutineScope(Job() + Dispatchers.Main)
+
     private val wifiCallback: (Boolean) -> Unit = { isWifi ->
-        Log.d(TAG, "isWifi: $isWifi")
-        launchSubActivity()
+        Log.d(TAG, "isWifi: $isWifi, request api")
+        scope.launch {
+            val result = ApiClient().getMockResponse()
+            if (result) launchSubActivity()
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/example/networkobserverdemo/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/example/networkobserverdemo/data/source/remote/ApiClient.kt
@@ -1,0 +1,15 @@
+package com.example.networkobserverdemo.data.source.remote
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+class ApiClient {
+
+    suspend fun getMockResponse(): Boolean {
+        return withContext(Dispatchers.IO) {
+            delay(3000)
+            true
+        }
+    }
+}


### PR DESCRIPTION
# 概要
非同期のAPI通信を想定して、コルーチンで遅延を表現してレスポンスを返すようにした。

# 詳細
### SubActivity起動までの想定フロー
1. Wifi接続の場合、コルーチンを開始し仮のAPIリクエストをする
2. この仮のリクエストは遅延してレスポンスする
3. レスポンス取得後、SubActivityを起動する

### Jobのキャンセルと新規作成
2のリクエスト中にアプリをバックグラウンドにし、バックグラウンド中にレスポンスを受け取ると、startActivityを行いSubActivityが起動してしまう。
→ アプリが強制的にフォアグラウンドになってしまう。

これを防ぐために、リクエスト中にアプリがバックグラウンドに移行した場合、Jobをキャンセルして仮のAPIレスポンスを受け取らないようにした。

Jobはアプリのライフサイクル onStart で都度新しいインスタンスを作る。

# 参考
### Jobのキャンセル、中断
- [How to restart job after cancel in kotlin coroutines?](https://stackoverflow.com/questions/59628666/how-to-restart-job-after-cancel-in-kotlin-coroutines)
- [図で理解する Kotlin Coroutine](https://qiita.com/kawmra/items/d024f9ab32ffe0604d39#%E5%85%B7%E4%BD%93%E7%9A%84%E3%81%AA%E4%BE%8B)