### PR TITLE
add send broadcast finish app to mainActivity

### DIFF
--- a/app/src/main/java/com/example/networkobserverdemo/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/networkobserverdemo/ui/MainActivity.kt
@@ -1,7 +1,12 @@
 package com.example.networkobserverdemo.ui
 
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import com.example.networkobserverdemo.R
@@ -10,10 +15,29 @@ import com.example.networkobserverdemo.viewmodel.MainViewModel
 
 class MainActivity : AppCompatActivity() {
 
+    companion object {
+        private const val TAG = "Main" + " mori"
+    }
+
     private lateinit var viewModel: MainViewModel
+
+    private val receiveIntent = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            intent?.let {
+            Log.d(TAG, "onReceive, intent action: ${intent.action}")
+                when (it.action) {
+                    INTENT_ACTION_FINISH_APP -> {
+                        Log.d(TAG, "finish app")
+                        finish()
+                    }
+                }
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.d(TAG, "onCreate, $this")
         setContentView(R.layout.activity_main)
 
         // set binding and viewModel
@@ -21,5 +45,17 @@ class MainActivity : AppCompatActivity() {
         val binding =
             DataBindingUtil.setContentView<ActivityMainBinding>(this, R.layout.activity_main)
         binding.viewModel = viewModel
+
+        val filter = IntentFilter().apply {
+            addAction(INTENT_ACTION_FINISH_APP)
+        }
+        registerReceiver(receiveIntent, filter)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        unregisterReceiver(receiveIntent) // Activityがバックグラウンド時もIntentを受け取りたいのでonDestroyで実行
     }
 }
+
+const val INTENT_ACTION_FINISH_APP = "com.example.networkobserverdemo_finish_app"

--- a/app/src/main/java/com/example/networkobserverdemo/ui/SubActivity.kt
+++ b/app/src/main/java/com/example/networkobserverdemo/ui/SubActivity.kt
@@ -55,4 +55,14 @@ class SubActivity : AppCompatActivity() {
         }
         startActivity(intent)
     }
+
+
+    override fun onBackPressed() {
+        super.onBackPressed()
+        val intent = Intent().apply {
+            action = INTENT_ACTION_FINISH_APP
+        }
+        sendBroadcast(intent)
+        Log.d(TAG, "sendBroadcast, intent action: ${intent.action}")
+    }
 }


### PR DESCRIPTION
# 概要
SubActivityにてバックボタンを押した場合は強制的にアプリを終了する。
それを実現するためにBroadcastReceiverを使用した。

# 詳細
MainActivityではonDestroyされるまでブロードキャストを受け付けるようにする。
バックボタンが押された時に以下処理がされる。
- SubActivity#onBackPressedにて、ブロードキャストを送信する
- MainActivityにてブロードキャストを受け取り、SubActivityから送信されたIntentだった場合は finish() する

MainActivityはルートアクティビティのため、finish() すればアプリが終了する。