### PR TITLE
add startActivity intent to finish mainActivity

### DIFF
--- a/app/src/main/java/com/example/networkobserverdemo/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/networkobserverdemo/ui/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.example.networkobserverdemo.ui
 
-import androidx.appcompat.app.AppCompatActivity
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import com.example.networkobserverdemo.R
@@ -9,6 +11,10 @@ import com.example.networkobserverdemo.databinding.ActivityMainBinding
 import com.example.networkobserverdemo.viewmodel.MainViewModel
 
 class MainActivity : AppCompatActivity() {
+
+    companion object {
+        private const val TAG = "Main" + " mori"
+    }
 
     private lateinit var viewModel: MainViewModel
 
@@ -22,4 +28,16 @@ class MainActivity : AppCompatActivity() {
             DataBindingUtil.setContentView<ActivityMainBinding>(this, R.layout.activity_main)
         binding.viewModel = viewModel
     }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.let {
+            Log.d(TAG, "intent action: ${it.action}")
+            when (it.action) {
+                INTENT_ACTION_FINISH_APP -> finish()
+            }
+        }
+    }
 }
+
+const val INTENT_ACTION_FINISH_APP = "com.example.networkobserverdemo_finish_app"

--- a/app/src/main/java/com/example/networkobserverdemo/ui/SubActivity.kt
+++ b/app/src/main/java/com/example/networkobserverdemo/ui/SubActivity.kt
@@ -55,4 +55,15 @@ class SubActivity : AppCompatActivity() {
         }
         startActivity(intent)
     }
+
+    override fun onBackPressed() {
+        super.onBackPressed()
+        val intent = Intent(this, MainActivity::class.java).apply {
+            // onNewIntentでこのアクションを受け取るとMainActivity（ルートアクティビティ）はfinishする、すなわちアプリ終了
+            action = INTENT_ACTION_FINISH_APP
+            // MainActivityの上にあるスタックをクリア、そして新しいインスタンスは作らずonNewIntentで受け取らせる
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        startActivity(intent)
+    }
 }


### PR DESCRIPTION
概要
SubActivityにてバックボタンを押した場合は強制的にアプリを終了する。
#7 ではBroadcastReceiverを使用したが、こちらはstartActivityのIntentフラグにより、MainActivity#onNewIntentで終了処理をさせる。

詳細
MainActivityでは、onNewIntentでアプリ終了のIntentアクションを受け取るとfinishさせる。
バックボタンが押された時に以下処理がされる。

SubActivity#onBackPressedにて、startActivityする。
（フラグでMainActivityの上にあるスタックを削除し、新規インスタンスを作らないようにする → onNewIntentで受け取れる）
MainActivity#onNewIntentを受け取り、アプリ終了のIntentアクションだった場合は finish() する。
MainActivityはルートアクティビティのため、finish() すればアプリが終了する。